### PR TITLE
fix: Builds were failing with `transformImportInline is not defined`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-quintype-assets",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "author": "Quintype Developers <dev-core@quintype.com>",
   "license": "ISC",
   "dependencies": {
-    "babel-plugin-transform-assets-import-to-string": "^1.0.1"
+    "babel-plugin-transform-assets-import-to-string": "~1.0.1"
   }
 }


### PR DESCRIPTION
fix: Builds were failing with `transformImportInline is not defined` error due to the upgraded dependency inconsistencies.